### PR TITLE
resolves #1

### DIFF
--- a/ImageChecker/Converter/BooleanAllFalseToTrueConverter.cs
+++ b/ImageChecker/Converter/BooleanAllFalseToTrueConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+
+namespace ImageChecker.Converter
+{
+    public class BooleanAllFalseToTrueConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return values.All(a => a is bool b && b == false);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ImageChecker/Imaging/CustomFLANN.cs
+++ b/ImageChecker/Imaging/CustomFLANN.cs
@@ -35,38 +35,35 @@ namespace ImageChecker.Imaging
             {
                 try
                 {
-                    using (var fs = File.OpenRead(@"\\?\" + fileName))
+                    using var fs = File.OpenRead(@"\\?\" + fileName);
+
+                    var bmi = new BitmapImage();
+                    bmi.BeginInit();
+                    bmi.StreamSource = fs;
+                    bmi.CacheOption = BitmapCacheOption.OnLoad;
+                    bmi.EndInit();
+                    bmi.Freeze();
+
+                    using var bm = bmi.ToDrawingBitmap();
+
+                    using var origImage = bm.ToMat();
+                    using var scaledImage = new Mat();
+                    using var grayedImage = new Mat();
+
+                    if (preResizeImages)
                     {
-                        var bmi = new BitmapImage();
-                        bmi.BeginInit();
-                        bmi.StreamSource = fs;
-                        bmi.CacheOption = BitmapCacheOption.OnLoad;
-                        bmi.EndInit();
-                        bmi.Freeze();
-
-                        using (var bm = bmi.ToDrawingBitmap())
-                        {
-                            using (var origImage = bm.ToMat())
-                            using (var scaledImage = new Mat())
-                            using (var grayedImage = new Mat())
-                            {
-                                if (preResizeImages)
-                                {
-                                    Cv2.Resize(origImage, scaledImage, new Size(preResizeScale, preResizeScale), 0D, 0D, InterpolationFlags.Cubic);
-                                }
-                                else
-                                {
-                                    origImage.CopyTo(scaledImage);
-                                }
-
-                                Cv2.CvtColor(scaledImage, grayedImage, ColorConversionCodes.BGR2GRAY);
-                                origImage.Dispose();
-                                scaledImage.Dispose();
-
-                                this.surfDetector.DetectAndCompute(grayedImage, null, out _, descriptors);
-                            }
-                        }
+                        Cv2.Resize(origImage, scaledImage, new Size(preResizeScale, preResizeScale), 0D, 0D, InterpolationFlags.Cubic);
                     }
+                    else
+                    {
+                        origImage.CopyTo(scaledImage);
+                    }
+
+                    Cv2.CvtColor(scaledImage, grayedImage, ColorConversionCodes.BGR2GRAY);
+                    origImage.Dispose();
+                    scaledImage.Dispose();
+
+                    this.surfDetector.DetectAndCompute(grayedImage, null, out _, descriptors);
 
                     preLoadedFileImagesSource.Add(new FileImage(fileName, descriptors));
                 }

--- a/ImageChecker/Processing/WorkerImageComparison.cs
+++ b/ImageChecker/Processing/WorkerImageComparison.cs
@@ -1,17 +1,17 @@
 ﻿using ImageChecker.Concurrent;
 using ImageChecker.DataClass;
+using ImageChecker.Helper;
+using ImageChecker.Imaging;
+using ImageChecker.ViewModel;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using ImageChecker.Imaging;
-using ImageChecker.ViewModel;
-using System.Diagnostics;
-using ImageChecker.Helper;
 
 namespace ImageChecker.Processing
 {
@@ -143,7 +143,7 @@ namespace ImageChecker.Processing
             {
                 if (possibleDuplicates == null)
                     possibleDuplicates = new ConcurrentBag<ImageCompareResult>();
-                
+
                 return possibleDuplicates;
             }
             set
@@ -243,10 +243,10 @@ namespace ImageChecker.Processing
         {
             switch (e.PropertyName)
             {
-                case "ErrorFiles":
+                case nameof(ErrorFiles):
                     HasErrorFiles = ErrorFiles.Any();
                     break;
-                case "PossibleDuplicates":
+                case nameof(PossibleDuplicates):
                     HasPossibleDuplicates = PossibleDuplicates.Any();
                     break;
                 case nameof(this.SelectedPossibleDuplicatesCount):
@@ -266,6 +266,8 @@ namespace ImageChecker.Processing
 
         public async Task Start()
         {
+            PossibleDuplicates = new ConcurrentBag<ImageCompareResult>();
+
             await ReadFileNameForImageComarisonAsync();
         }
 
@@ -293,7 +295,7 @@ namespace ImageChecker.Processing
                 currentProgress = new ProgressImageComparison(0, Files.Count, 0, "preparing", null, null);
 
                 ImageComparisonProgressInterface.Report(new ProgressImageComparison(currentProgress.Minimum, currentProgress.Maximum, currentProgress.Value, currentProgress.Operation, null, null));
-                
+
                 if (Files.Count > 0)
                 {
                     Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
@@ -318,9 +320,9 @@ namespace ImageChecker.Processing
             // reset stuff
             ErrorFiles = new ConcurrentBag<string>();
             HasErrorFiles = false;
-            possibleDuplicates = new ConcurrentBag<ImageCompareResult>();
+            PossibleDuplicates = new ConcurrentBag<ImageCompareResult>();
             HasPossibleDuplicates = false;
-            
+
             await Task.Run(async () =>
             {
                 CustomFLANN cf = new CustomFLANN();
@@ -368,7 +370,7 @@ namespace ImageChecker.Processing
                 currentProgress.Operation = "loading files canceled!";
                 ImageComparisonProgressInterface.Report(new ProgressImageComparison(currentProgress.Minimum, currentProgress.Maximum, currentProgress.Value, currentProgress.Operation, null, null));
                 return;
-            } 
+            }
             #endregion
 
             timer.Restart();
@@ -421,7 +423,7 @@ namespace ImageChecker.Processing
                 {
                     Task imageTask = await Task.WhenAny(imageTasks).ConfigureAwait(false);
                     imageTasks.Remove(imageTask);
-                    
+
                     currentProgress.Value++;
 
                     // gauss berechnung und stopwatch verwenden
@@ -449,7 +451,7 @@ namespace ImageChecker.Processing
 
 
             HasPossibleDuplicates = PossibleDuplicates.Any();
-            
+
             if (CtsImageComparison.IsCancellationRequested)
             {
                 IsComparingImages = false;
@@ -518,7 +520,7 @@ namespace ImageChecker.Processing
                 ctsImageComparison.Dispose();
                 ctsImageComparison = null;
             }
-        } 
+        }
         #endregion
     }
 }

--- a/ImageChecker/View/ImageChecker.xaml
+++ b/ImageChecker/View/ImageChecker.xaml
@@ -42,7 +42,17 @@
                     <Button ToolTip="Clear Directories" Grid.Column="4" Command="{Binding ClearFoldersCommand}" Margin="2,0" Height="19" BorderThickness="0" Background="Transparent">
                         <Image Source="/ImageChecker;component/Icon/clear_folders.png" Stretch="Uniform" />
                     </Button>
-                    <CheckBox Content="include subdirectories" Grid.Column="5" Margin="5,0" VerticalAlignment="Center" IsChecked="{Binding IncludeSubdirectories, Mode=TwoWay}"/>
+                    <CheckBox Content="include subdirectories" Grid.Column="5" Margin="5,0" VerticalAlignment="Center" IsChecked="{Binding IncludeSubdirectories, Mode=TwoWay}">
+                        <CheckBox.Resources>
+                            <converter:BooleanAllFalseToTrueConverter x:Key="BooleanAllFalseToTrueConverter" />
+                        </CheckBox.Resources>
+                        <CheckBox.IsEnabled>
+                            <MultiBinding Converter="{StaticResource BooleanAllFalseToTrueConverter}">
+                                <Binding Path="WorkerRenameFiles.IsRenamingFiles" />
+                                <Binding Path="WorkerImageComparison.IsComparingImages" />
+                            </MultiBinding>
+                        </CheckBox.IsEnabled>
+                    </CheckBox>
                 </Grid>
             </GroupBox.Header>
             <ListBox x:Name="lbDirectories" ScrollViewer.VerticalScrollBarVisibility="Auto" BorderThickness="0"


### PR DESCRIPTION
resolves #1 
- folder changes now only permitted when no worker is running
- image compare results get cleared when folder changes or start is clicked