### PR TITLE
little correction on file deletion

### DIFF
--- a/ImageChecker/ViewModel/VMErrorFiles.cs
+++ b/ImageChecker/ViewModel/VMErrorFiles.cs
@@ -68,7 +68,7 @@ namespace ImageChecker.ViewModel
 
             if (fi != null)
             {
-                FileOperationAPIWrapper.Send(fi.FullName);
+                FileOperationAPIWrapper.Send(fi.FullName, FileOperationAPIWrapper.FileOperationFlags.FOF_ALLOWUNDO | FileOperationAPIWrapper.FileOperationFlags.FOF_NOCONFIRMATION | FileOperationAPIWrapper.FileOperationFlags.FOF_SILENT);
             }
         }
 
@@ -182,7 +182,7 @@ namespace ImageChecker.ViewModel
         {
             foreach (FileInfo fi in ErrorFiles.Where(a => File.Exists(a.FullName)))
             {
-                FileOperationAPIWrapper.Send(fi.FullName);
+                FileOperationAPIWrapper.Send(fi.FullName, FileOperationAPIWrapper.FileOperationFlags.FOF_ALLOWUNDO | FileOperationAPIWrapper.FileOperationFlags.FOF_NOCONFIRMATION | FileOperationAPIWrapper.FileOperationFlags.FOF_SILENT);
             }
         }
 

--- a/ImageChecker/ViewModel/VMResultView.cs
+++ b/ImageChecker/ViewModel/VMResultView.cs
@@ -501,7 +501,7 @@ namespace ImageChecker.ViewModel
 
             if (fi != null)
             {
-                FileOperationAPIWrapper.Send(fi.FullName);
+                FileOperationAPIWrapper.Send(fi.FullName, FileOperationAPIWrapper.FileOperationFlags.FOF_ALLOWUNDO | FileOperationAPIWrapper.FileOperationFlags.FOF_NOCONFIRMATION | FileOperationAPIWrapper.FileOperationFlags.FOF_SILENT);
             }
 
             if (IsExterminationModeActive)
@@ -725,7 +725,7 @@ namespace ImageChecker.ViewModel
 
             foreach (var fi in smallerOnes.Select(a => a.FullName).Distinct())
             {
-                FileOperationAPIWrapper.Send(fi);
+                FileOperationAPIWrapper.Send(fi, FileOperationAPIWrapper.FileOperationFlags.FOF_ALLOWUNDO | FileOperationAPIWrapper.FileOperationFlags.FOF_NOCONFIRMATION | FileOperationAPIWrapper.FileOperationFlags.FOF_SILENT);
             }
         }
 


### PR DESCRIPTION
added parameters to the sendToRecycleBin calls to suppress the UI-focus-switch that was happening. reason was that if a user request was possibly needed the UI focus was captured shortly. after the operation finished the focus got restored but the switch takes unneeded time and was clearly visible to the user.