### PR TITLE
improving keyboard navigation in resultView

### DIFF
--- a/ImageChecker/View/ResultView.xaml
+++ b/ImageChecker/View/ResultView.xaml
@@ -20,6 +20,8 @@
     <UserControl.InputBindings>
         <KeyBinding Command="{Binding DeleteFileCommand}" CommandParameter="{Binding SelectedResult.FileA.File}" Key="Left" />
         <KeyBinding Command="{Binding DeleteFileCommand}" CommandParameter="{Binding SelectedResult.FileB.File}" Key="Right" />
+        <KeyBinding Command="{Binding MoveSelectionUpCommand}" Key="Up" Modifiers="Ctrl"/>
+        <KeyBinding Command="{Binding MoveSelectionDownCommand}" Key="Down" Modifiers="Ctrl" />
     </UserControl.InputBindings>
     
     <Grid>
@@ -180,7 +182,7 @@
             </controls:MultiSelectDataGrid.Columns>
         </controls:MultiSelectDataGrid>
 
-        <GridSplitter Grid.Row="3" Height="10" HorizontalAlignment="Stretch" Margin="5,0">
+        <GridSplitter Grid.Row="3" Height="10" HorizontalAlignment="Stretch" Margin="5,0" IsTabStop="False">
             <GridSplitter.Template>
                 <ControlTemplate TargetType="{x:Type GridSplitter}">
                     <Border BorderBrush="{TemplateBinding BorderBrush}"
@@ -243,7 +245,7 @@
                     </TextBlock.Text>
                 </TextBlock>
                 <Button Grid.Row="1" Command="{Binding ImageClickCommand}" CommandParameter="{Binding SelectedResult.FileA}" Style="{StaticResource EmptyButtonStyle}" 
-                        ContextMenuService.ShowOnDisabled="True">
+                        ContextMenuService.ShowOnDisabled="True" IsTabStop="False">
                     <Grid>
                         <Border BorderBrush="{Binding SelectedResult.SmallerOne, Converter={StaticResource ImageBorderBrushA}}" BorderThickness="5" Margin="-5">
                             <Border.Visibility>
@@ -367,7 +369,7 @@
                 </TextBlock>
 
                 <Button Grid.Row="1" Command="{Binding ImageClickCommand}" CommandParameter="{Binding SelectedResult.FileB}" Style="{StaticResource EmptyButtonStyle}" 
-                        ContextMenuService.ShowOnDisabled="True">
+                        ContextMenuService.ShowOnDisabled="True" IsTabStop="False">
                     <Grid>
                         <Border BorderBrush="{Binding SelectedResult.SmallerOne, Converter={StaticResource ImageBorderBrushB}}" BorderThickness="5" Margin="-5">
                             <Border.Visibility>

--- a/ImageChecker/ViewModel/VMResultView.cs
+++ b/ImageChecker/ViewModel/VMResultView.cs
@@ -263,6 +263,35 @@ namespace ImageChecker.ViewModel
             }
         }
 
+        private void SelectPreviousUnsolvedResult()
+        {
+            if (SelectedResult != null && Results != null)
+            {
+                var item = SelectedResult; // save it cause of the bug?
+
+                var view = ResultsView.View.OfType<ImageCompareResult>().ToList(); // this line magically changes the 'SelectedResult' to the first in the listing...???? -> its a bug, not a feature
+
+                item = view.Take(view.IndexOf(item)).LastOrDefault(a => a.IsSolved == false);
+
+                if (item != null)
+                {
+                    SelectedResult = item;
+                }
+                else
+                {
+                    item = view.LastOrDefault(a => a.IsSolved == false);
+
+                    if (item != null)
+                    {
+                        SelectedResult = item;
+                    }
+                }
+
+                // scroll into view
+
+            }
+        }
+
         private void UnloadImages(List<ImageCompareResult> results)
         {
             foreach (var r in results)
@@ -519,7 +548,60 @@ namespace ImageChecker.ViewModel
 
             return false;
         }
-        #endregion
+        #endregion DeleteFile
+
+        #region MoveSelectionDown
+        private ICommand moveSelectionDownCommand;
+        public ICommand MoveSelectionDownCommand
+        {
+            get
+            {
+                if (moveSelectionDownCommand == null)
+                {
+                    moveSelectionDownCommand = new RelayCommand(p => MoveSelectionDown(),
+                        p => CanMoveSelectionDown());
+                }
+                return moveSelectionDownCommand;
+            }
+        }
+
+        public void MoveSelectionDown()
+        {
+            SelectNextUnsolvedResult();
+        }
+
+        private bool CanMoveSelectionDown()
+        {
+            return true;
+        }
+        #endregion MoveSelectionUp
+
+        #region MoveSelectionUp
+        private ICommand moveSelectionUpCommand;
+        public ICommand MoveSelectionUpCommand
+        {
+            get
+            {
+                if (moveSelectionUpCommand == null)
+                {
+                    moveSelectionUpCommand = new RelayCommand(p => MoveSelectionUp(),
+                        p => CanMoveSelectionUp());
+                }
+                return moveSelectionUpCommand;
+            }
+        }
+
+        public void MoveSelectionUp()
+        {
+            SelectPreviousUnsolvedResult();
+        }
+
+        private bool CanMoveSelectionUp()
+        {
+            return true;
+        }
+        #endregion MoveSelectionUp
+
         #region OpenFolder
         private ICommand openFolderCommand;
         public ICommand OpenFolderCommand
@@ -558,10 +640,9 @@ namespace ImageChecker.ViewModel
 
             return false;
         }
-        #endregion
+        #endregion OpenFolder
+
         #region ImageClick
-
-
         private ICommand imageClickCommand;
         public ICommand ImageClickCommand
         {
@@ -614,6 +695,7 @@ namespace ImageChecker.ViewModel
             return false;
         }
         #endregion ImageClick
+
         #region CutFile
         private ICommand cutFileCommand;
         public ICommand CutFileCommand
@@ -647,7 +729,8 @@ namespace ImageChecker.ViewModel
 
             return false;
         }
-        #endregion 
+        #endregion CutFile
+
         #region CutSmallerOnes
         private ICommand cutSmallerOnesCommand;
         public ICommand CutSmallerOnesCommand
@@ -691,7 +774,8 @@ namespace ImageChecker.ViewModel
 
             return true;
         }
-        #endregion 
+        #endregion CutSmallerOnes
+
         #region DeleteSmallerOnes
         private ICommand deleteSmallerOnesCommand;
         public ICommand DeleteSmallerOnesCommand
@@ -736,7 +820,8 @@ namespace ImageChecker.ViewModel
 
             return true;
         }
-        #endregion 
+        #endregion DeleteSmallerOnes
+
         #region RestoreImage
         private ICommand restoreImageCommand;
         public ICommand RestoreImageCommand
@@ -772,7 +857,8 @@ namespace ImageChecker.ViewModel
             return true;
 
         }
-        #endregion 
+        #endregion RestoreImage
+
         #region SaveAsImage
         private ICommand saveAsImageCommand;
         public ICommand SaveAsImageCommand
@@ -818,7 +904,8 @@ namespace ImageChecker.ViewModel
 
             return true;
         }
-        #endregion
+        #endregion SaveAsImage
+
         #region RestoreSelectedImages
         private ICommand restoreSelectedImagesCommand;
         public ICommand RestoreSelectedImagesCommand
@@ -857,8 +944,8 @@ namespace ImageChecker.ViewModel
             return true;
 
         }
-        #endregion 
-        #endregion
+        #endregion RestoreSelectedImages
+        #endregion Commands
 
         #region IDisposable
         public void Dispose()


### PR DESCRIPTION
in resultView with ctrl + up/down it is now possible to navigate to the next/previous unsolved item in the list.

solves #9 